### PR TITLE
Add Passive TCP connection to IDL.

### DIFF
--- a/python/ovs/db/idl.py
+++ b/python/ovs/db/idl.py
@@ -86,7 +86,7 @@ class Idl(object):
       currently being constructed, if there is one, or None otherwise.
 """
 
-    def __init__(self, remote, schema):
+    def __init__(self, remote, schema, session=None):
         """Creates and returns a connection to the database named 'db_name' on
         'remote', which should be in a form acceptable to
         ovs.jsonrpc.session.open().  The connection will maintain an in-memory
@@ -104,7 +104,16 @@ class Idl(object):
         As a convenience to users, 'schema' may also be an instance of the
         SchemaHelper class.
 
-        The IDL uses and modifies 'schema' directly."""
+        The IDL uses and modifies 'schema' directly.
+
+        In passive mode ( where the OVSDB server connects to its manager ),
+        we first need to wait for the OVSDB server to connect and then
+        pass the 'session' object (while the it is still open ) and
+        the schema we retrieved from the open session to the IDL to use it.
+
+        If in active mode, do not pass 'session' and it will be created
+        by IDL by using 'remote'.
+        """
 
         assert isinstance(schema, SchemaHelper)
         schema = schema.get_idl_schema()
@@ -112,7 +121,10 @@ class Idl(object):
         self.tables = schema.tables
         self.readonly = schema.readonly
         self._db = schema
-        self._session = ovs.jsonrpc.Session.open(remote)
+        if session:
+            self._session = session
+        else:
+            self._session = ovs.jsonrpc.Session.open(remote)
         self._monitor_request_id = None
         self._last_seqno = None
         self.change_seqno = 0

--- a/tests/ovsdb-idl.at
+++ b/tests/ovsdb-idl.at
@@ -111,6 +111,37 @@ m4_define([OVSDB_CHECK_IDL],
    OVSDB_CHECK_IDL_TCP_PY($@)
    OVSDB_CHECK_IDL_TCP6_PY($@)])
 
+
+# This test uses the Python IDL implementation with passive tcp
+m4_define([OVSDB_CHECK_IDL_PASSIVE_TCP_PY],
+  [AT_SETUP([$1 - Python ptcp])
+   AT_SKIP_IF([test $HAVE_PYTHON = no])
+   AT_KEYWORDS([ovsdb server idl positive Python with tcp socket $5])
+   AT_CHECK([ovsdb-tool create db $abs_srcdir/idltest.ovsschema],
+                  [0], [stdout], [ignore])
+   # find free TCP port
+   AT_CHECK([ovsdb-server --log-file '-vPATTERN:console:ovsdb-server|%c|%m' --detach --no-chdir --pidfile="`pwd`"/pid --remote=punix:socket --remote=ptcp:0:127.0.0.1 --unixctl="`pwd`"/unixctl db], [0], [ignore], [ignore])
+   PARSE_LISTENING_PORT([ovsdb-server.log], [TCP_PORT])
+   AT_CHECK([kill `cat pid`])
+
+   # start OVSDB server in passive mode
+   AT_CHECK([ovsdb-server --log-file '-vPATTERN:console:ovsdb-server|%c|%m' --detach --no-chdir --pidfile="`pwd`"/pid --remote=punix:socket --remote=tcp:127.0.0.1:$TCP_PORT --unixctl="`pwd`"/unixctl db], [0], [ignore], [ignore])
+   AT_CHECK([$PYTHON $srcdir/test-ovsdb.py -t10 idl $srcdir/idltest.ovsschema ptcp:127.0.0.1:$TCP_PORT $3],
+      [0], [stdout], [ignore], [kill `cat pid`])
+   AT_CHECK([sort stdout | ${PERL} $srcdir/uuidfilt.pl]m4_if([$6],,, [[| $6]]),
+            [0], [$4], [], [kill `cat pid`])
+   AT_CLEANUP
+   ])
+
+
+OVSDB_CHECK_IDL_PASSIVE_TCP_PY([simple passive idl, initially empty, select empty],
+  [],
+  [['["idltest",{"op":"select","table":"link1","where":[]}]']],
+  [[000: empty
+001: {"error":null,"result":[{"rows":[]}]}
+002: done
+]])
+
 OVSDB_CHECK_IDL([simple idl, initially empty, no ops],
   [],
   [],


### PR DESCRIPTION
Currently the IDL does not support passive TCP connection,
i.e. when the OVSDB connects to its manager.

This patch enables IDL to use an already-open session
(the one which was previously used for retrieving the db schema).
In addition, it enables IDL to go back to "listen mode" in case the connection
is lost.
## LIMITATIONS:

This patch enables a **SINGLE** TCP connection from an OVSDB server to an
agent that uses IDL with {IP,PORT} pair. Therefore, the agent will support
only **ONE** OVSDB server using {IP,PORT} pair.

Future development may add multi-session server capability that will allow
an agent to use single {IP,PORT} pair to connect to multiple OVSDB servers.
## CAVEAT:

When a database first connects to the agent, the agent gets the schema and
data and builds its tables. If the session disconnects, the agent goes back
to "listen mode" and accepts **ANY** TCP connection, which means that if
another database will try to connect to the agent using the same {IP,PORT}
pair, it will be connected to the IDL that has the schema and data from
the first database.

A future patch can resolve this problem.
## USAGE:

To use IDL in passive mode, the following example code can be use:

(snippet)

from ovs.jsonrpc import Session
...

from neutron.agent.ovsdb.native import idlutils

...

session = Session.open('ptcp:192.168.10.10:6640')
# first call to session.run creates the PassiveStream object and second one
# accept incoming connection

session.run()
session.run()
# this static method is similar to the original neutron method but the
# rpc.close() command that would result closing the socket.

helper = idlutils.get_schema_helper_from_stream_no_close(session.stream,
        'hardware_vtep')
helper.register_all()
self.idl = idl.Idl(self.connection, helper, session)
idlutils.wait_for_change(self.idl, self.timeout)

self.poller = poller.Poller()
self.thread = threading.Thread(target=self.run)
self.thread.setDaemon(True)
self.thread.start()
## TESTING:

Added unit test for passive mode. See ovsdb-idl.at file.
## TODO

Test this patch against C implementation

Signed-off-by: "Ofer Ben-Yacov" ofer.benyacov@gmail.com

Tested-by: "Ofer Ben-Yacov" ofer.benyacov@gmail.com

Requested-by: Ben Pfaff blp@nicira.com,
Requested-by: "D M, Vikas" vikas.d-m@hpe.com,
Requested-by: "Kamat, Maruti Haridas" maruti.kamat@hpe.com,
Requested-by: "Sukhdev Kapur" sukhdev@arista.com,
Requested-by: "Migliaccio, Armando" armando.migliaccio@hpe.com
