### PR TITLE
travis: Install Python 3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ addons:
       - libssl-dev
       - llvm-dev
 
+python:
+  - 2.7
+  - 3.4
+
 before_install: ./.travis/prepare.sh
 
 before_script: export PATH=$PATH:$HOME/bin


### PR DESCRIPTION
Install Python 3 on travis-ci so that the Python 3 tests run in the test
suite.

Signed-off-by: Russell Bryant russell@ovn.org
